### PR TITLE
Fix env var path in stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - Add missing call to extract video dimensions for local video files
 
+## 1.0.2 - 2025-05-07
+
+### Fixed
+
+- Parse environment variables for local filesystem paths
+- Parse environment variables for streamed video paths
+
+
 ## 1.0.0 - 2025-05-01
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ynmstudio/craft-video-dimensions-universal",
   "description": "A Craft CMS plugin that automatically extracts and saves video dimensions after upload.",
   "type": "craft-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "keywords": [
     "craft",
     "cms",

--- a/src/VideoDimensionsUniversal.php
+++ b/src/VideoDimensionsUniversal.php
@@ -7,6 +7,7 @@ use craft\base\Plugin;
 use craft\elements\Asset;
 use craft\events\ModelEvent;
 use craft\helpers\FileHelper;
+use craft\helpers\App;
 use craft\records\Asset as AssetRecord;
 use craft\models\Volume;
 use craft\base\Fs as BaseFs;
@@ -132,8 +133,8 @@ class VideoDimensionsUniversal extends Plugin
      */
     protected function processLocalVideo(Asset $asset, BaseFs $filesystem, Volume $volume): ?array
     {
-        $fsPath = Craft::getAlias($filesystem->path);
-        $subPath = Craft::getAlias($volume->subpath);
+        $fsPath = Craft::getAlias(App::parseEnv($filesystem->path));
+        $subPath = Craft::getAlias(App::parseEnv($volume->subpath));
         $assetFilePath = FileHelper::normalizePath(
             $fsPath . DIRECTORY_SEPARATOR . $subPath . DIRECTORY_SEPARATOR . $asset->getPath()
         );
@@ -156,7 +157,7 @@ class VideoDimensionsUniversal extends Plugin
 
         // NOTE: In this Craft Cloud setup, the subpath must be prepended to the asset path for getFileStream to work correctly.
         $expectedPath = $asset->getPath();
-        $subPath = $asset->getVolume()->subpath ?? '';
+        $subPath = Craft::getAlias(App::parseEnv($asset->getVolume()->subpath ?? ''));
         if ($subPath && strpos($expectedPath, $subPath) !== 0) {
             $expectedPath = $subPath . '/' . $expectedPath;
         }


### PR DESCRIPTION
## Summary
- parse environment variables for local and streamed video paths using `App::parseEnv`
- bump version to 1.0.2
- document fix in changelog

## Testing
- `composer validate --no-check-publish` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855394627e4832580ddcae273571e79