### PR TITLE
Update craftcms/cloud version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "james-heinrich/getid3": "^1.9"
   },
   "require-dev": {
-    "craftcms/cloud": "^2.0.0"
+    "craftcms/cloud": "^2.0.0 || ^3.0.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
`craftcms/cloud:3.0.0` has been released and is a non-breaking from the consumer's end.