### PR TITLE
Add Craft CMS 4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Release Notes for Video Dimensions Universal
 
+## 1.1.0 - 2026-06-25
+
+### Added
+
+- Craft CMS 4 support — the plugin now runs on both Craft 4 and Craft 5
+
+### Fixed
+
+- Guard access to the Craft 5-only `Volume::$subpath` property so local video processing no longer errors on Craft 4
+
 ## 1.0.2 - 2025-07-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Added
 
 - Craft CMS 4 support — the plugin now runs on both Craft 4 and Craft 5
+- Allow Craft Cloud 3 (`craftcms/cloud` 3.x) ([#4])
 
 ### Fixed
 
 - Guard access to the Craft 5-only `Volume::$subpath` property so local video processing no longer errors on Craft 4
+
+[#4]: https://github.com/ynmstudio/craft-video-dimensions-universal/pull/4
 
 ## 1.0.2 - 2025-07-14
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Universal Video Dimensions plugin for Craft CMS 5.x
+# Universal Video Dimensions plugin for Craft CMS 4.x & 5.x
 
 This plugin automatically extracts and saves video dimensions after uploading video files in Craft CMS. It supports both local files and files hosted on S3 or other remote filesystems.
 
 ## Requirements
 
-- Craft CMS 5.0.0 or later
+- Craft CMS 4.0.0 or later (Craft 4 and 5 are both supported)
 - PHP 8.0.2 or later
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "james-heinrich/getid3": "^1.9"
   },
   "require-dev": {
-    "craftcms/cloud": "^2.0.0"
+    "craftcms/cloud": "^2.0.0 || ^3.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "ynmstudio/craft-video-dimensions-universal",
   "description": "A Craft CMS plugin that automatically extracts and saves video dimensions after upload.",
   "type": "craft-plugin",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "keywords": [
     "craft",
     "cms",
@@ -28,7 +28,7 @@
     }
   ],
   "require": {
-    "craftcms/cms": "^5.0.0",
+    "craftcms/cms": "^4.0.0 || ^5.0.0",
     "james-heinrich/getid3": "^1.9"
   },
   "require-dev": {

--- a/src/VideoDimensionsUniversal.php
+++ b/src/VideoDimensionsUniversal.php
@@ -134,7 +134,8 @@ class VideoDimensionsUniversal extends Plugin
     protected function processLocalVideo(Asset $asset, BaseFs $filesystem, Volume $volume): ?array
     {
         $fsPath = App::parseEnv($filesystem->path);
-        $subPath = App::parseEnv($volume->subpath);
+        // `Volume::$subpath` only exists in Craft 5; fall back to '' on Craft 4 (handled via Yii's __isset).
+        $subPath = App::parseEnv($volume->subpath ?? '');
         $assetFilePath = FileHelper::normalizePath(
             $fsPath . DIRECTORY_SEPARATOR . $subPath . DIRECTORY_SEPARATOR . $asset->getPath()
         );


### PR DESCRIPTION
## Summary

Makes the plugin run on **both Craft CMS 4 and 5** (previously Craft 5 only).

- Widen `craftcms/cms` constraint: `^5.0.0` → `^4.0.0 || ^5.0.0`
- Guard the one runtime incompatibility: `processLocalVideo()` read `Volume::$subpath` directly, but that property is **Craft 5-only** and throws `UnknownPropertyException` on Craft 4. Now uses `$volume->subpath ?? ''`, which is a no-op on Craft 5 and safely resolves to `''` on Craft 4 (via Yii's `__isset`). This matches the guard already used in the streamed-video path.
- Bump version `1.0.2` → `1.1.0`; update README requirements and CHANGELOG.

## Compatibility verification

Every Craft API the plugin uses was checked against the Craft `4.x` source. All exist identically in Craft 4 except `Volume::$subpath` (fixed above). Confirmed safe on Craft 4: `$schemaVersion` is typed `string` in `PluginTrait`, `init()` has no return type, `craft\fs\Local::$path`, `getFs()`, `getFileStream()`, `App::parseEnv()`, the `craft\base\Fs` base class, and the asset record's width/height columns. The `craft\cloud\fs\Fs` import is only referenced in a docblock, so it's harmless when Craft Cloud isn't installed.

## Notes

- `require-dev: craftcms/cloud ^2.0.0` still pins the plugin's own dev environment to Craft 5. This does not affect end users installing into a Craft 4 project (require-dev is ignored by consumers).
- `composer.lock` content-hash is now stale relative to the widened constraint (locked cms 5.7.4 still satisfies it). Run `composer update --lock` to refresh if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small compatibility change with a targeted null-coalesce on volume subpath; no auth, security, or data-model changes.
> 
> **Overview**
> **Adds Craft CMS 4 support** alongside Craft 5 by widening the `craftcms/cms` dependency to `^4.0.0 || ^5.0.0` and releasing **1.1.0** with README and CHANGELOG updates.
> 
> The only runtime fix is in **`processLocalVideo()`**: it no longer assumes Craft 5’s `Volume::$subpath` exists. It now uses `$volume->subpath ?? ''`, matching the guard already used on the streamed-video path, so local dimension extraction does not throw on Craft 4.
> 
> Dev dependencies also allow **`craftcms/cloud` 3.x** (`^2.0.0 || ^3.0.0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f939d4e326503bd168765d751b8c7099e0af20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->