### PR TITLE
Allow Craft Cloud 3 in dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@
 ### Added
 
 - Craft CMS 4 support — the plugin now runs on both Craft 4 and Craft 5
+- Allow Craft Cloud 3 (`craftcms/cloud` 3.x) ([#4])
 
 ### Fixed
 
 - Guard access to the Craft 5-only `Volume::$subpath` property so local video processing no longer errors on Craft 4
+
+[#4]: https://github.com/ynmstudio/craft-video-dimensions-universal/pull/4
 
 ## 1.0.2 - 2025-07-14
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "james-heinrich/getid3": "^1.9"
   },
   "require-dev": {
-    "craftcms/cloud": "^2.0.0"
+    "craftcms/cloud": "^2.0.0 || ^3.0.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Widen craftcms/cloud dev constraint to ^2.0.0 || ^3.0.0. Cloud 3.0.0 is non-breaking from the consumer's end. Folds in #4 (Tim Kelty) so 1.1.0 ships Craft 4 support and Cloud 3 together.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-dependency and changelog only; no runtime plugin code or production Composer requirements change.
> 
> **Overview**
> **Widens the dev-only `craftcms/cloud` constraint** so local/CI installs can use Cloud 2.x or 3.x (`^2.0.0 || ^3.0.0` in `composer.json`). Production `require` is unchanged.
> 
> **Documents the change in 1.1.0** release notes with a link to [#4](https://github.com/ynmstudio/craft-video-dimensions-universal/pull/4), alongside the existing Craft 4 support entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b709523c26d0eb2bfc0c2922c19515e763c912e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->